### PR TITLE
fix(codegen): rebind event listeners in Show component templates

### DIFF
--- a/packages/runtime/src/compiler/codegen.test.ts
+++ b/packages/runtime/src/compiler/codegen.test.ts
@@ -218,4 +218,42 @@ describe('Code Generator: Forコンポーネントの詳細テスト', () => {
     expect(output).toContain('node._q_texts')
     expect(output).toContain('tn.textContent !== val')
   })
+
+  test('Showコンポーネント: onclickハンドラがrebind関数内で再アタッチされること', () => {
+    const ctx = new ComponentContext('Test')
+    ctx.addState('visible', true)
+    const visibleId = ctx.getNodeByKey('visible')?.id
+
+    ctx.addHandler('close', (_s: unknown) => {}, [])
+    const handlerId = ctx.getNodeByKey('close')?.id
+
+    ctx.instructions.push({
+      // biome-ignore lint/style/noNonNullAssertion: testing
+      signalId: visibleId!,
+      selector: '.modal-anchor',
+      action: 'show',
+      template: '<div class="close-btn"></div>',
+      templateId: 'tmpl-modal',
+    })
+
+    if (handlerId) {
+      ctx.instructions.push({
+        signalId: handlerId,
+        selector: '.close-btn',
+        action: 'addListener',
+        attrName: 'click',
+      })
+    }
+
+    const output = generateAppJs(ctx)
+
+    // rebind関数が定義されていること
+    expect(output).toContain('function _u_rebind_tmpl_modal()')
+
+    // rebind関数内でaddEventListenerが呼ばれていること
+    expect(output).toContain("addEventListener('click',")
+
+    // rebind関数がshow命令内で呼び出されていること
+    expect(output).toMatch(/_u_rebind_tmpl_modal\(\)/)
+  })
 })

--- a/packages/runtime/src/compiler/codegen.ts
+++ b/packages/runtime/src/compiler/codegen.ts
@@ -234,7 +234,23 @@ export function generateAppJs(context: ComponentContext) {
           return `    _e${idx} = root.${method}('${sel}');`
         })
         .join('\n')
-      return `  function _u_rebind_${tId}() {\n${rebindBody}\n  }`
+      // Re-attach event listeners for addListener instructions inside this template
+      const eventRebindBody = instructions
+        .filter(
+          i =>
+            i.action === 'addListener' &&
+            si.template?.includes(i.selector?.replace(/^\./, ''))
+        )
+        .map(i => {
+          const handlerNode = context.getNodeById(i.signalId)
+          if (!handlerNode || handlerNode.type !== 'handler') return ''
+          let body = handlerNode.fn.toString()
+          body = transformCode(body, context, idToShort)
+          const idx = selectors.indexOf(i.selector)
+          return `    if(_e${idx}) _e${idx}.addEventListener('${i.attrName}', ${body});`
+        })
+        .join('\n')
+      return `  function _u_rebind_${tId}() {\n${rebindBody}\n${eventRebindBody}\n  }`
     })
     .join('\n')
 


### PR DESCRIPTION
## 目的
Showコンポーネント内のonclickハンドラが動作しない問題を修正する

## 変更内容
- `codegen.ts`の`rebindFns`生成に、`addListener`命令の再アタッチ処理を追加
- Showテンプレートがクローンされた後に、内部要素のイベントリスナーが正しく再アタッチされるようにした
- テストケースを追加: Showコンポーネント内のonclickハンドラがrebind関数内で再アタッチされることを検証

## テスト
- [x] ユニットテストが通過 (59 pass, 0 fail)
- [ ] E2Eテストが通過（CIで確認）